### PR TITLE
add ltc backend

### DIFF
--- a/torchbench.py
+++ b/torchbench.py
@@ -450,6 +450,16 @@ def main():
         help="speedup using experimental fixed_strategy backend",
     )
     group.add_argument(
+        "--speedup-ltc",
+        action="store_true",
+        help="speedup using the ltc backend",
+    )
+    group.add_argument(
+        "--speedup-ltc-trivial",
+        action="store_true",
+        help="speedup using the ltc backend without reusing compiled graph",
+    )
+    group.add_argument(
         "--overhead", action="store_true", help=help(overhead_experiment)
     )
     group.add_argument(
@@ -520,6 +530,16 @@ def main():
         optimize_ctx = torchdynamo.optimize(offline_autotuner, nopython=args.nopython)
         experiment = speedup_experiment
         output_filename = "speedups.csv"
+        args.isolate = True
+    elif args.speedup_ltc:
+        optimize_ctx = torchdynamo.optimize(backends.ltc_reuse_graph, nopython=args.nopython)
+        experiment = speedup_experiment
+        output_filename = "speedups_ltc.csv"
+        args.isolate = True
+    elif args.speedup_ltc_trivial:
+        optimize_ctx = torchdynamo.optimize(backends.ltc_trivial, nopython=args.nopython)
+        experiment = speedup_experiment
+        output_filename = "speedups_ltc_trivial.csv"
         args.isolate = True
     elif args.speedup_fixed1:
         optimize_ctx = torchdynamo.optimize(fixed_strategy1, nopython=args.nopython)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1057,7 +1057,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
         if config.trace:
             print("INLINING ", code)
-            print(dis.dis(code))
+            dis.dis(code)
             print()
 
         if is_generator(code):


### PR DESCRIPTION
Add torchdynamo LTC backend. There are 2 version being added
- ltc_trivial : this one does not reuse LTC compiled graph and does tracing everytime. Adding this just for comparison purpose
- ltc_reuse_graph: this one will reuse the compiled LTC graph without retracing.

ltc_reuse_graph is implemented in the LTC PR: https://github.com/pytorch/pytorch/pull/72936 

Command:
LTC_TS_CUDA=1 gpui python torchbench.py --speedup-ltc-trivial -dcuda --only dlrm

cc @jansel 