### PR TITLE
IMPORT_NAME Instruction - Import the top-level package

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -942,3 +942,17 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertTrue(same(result1, result2))
         self.assertEqual(cnts.frame_count, 2)
         self.assertEqual(cnts.op_count, 11)
+
+    def test_top_package_import(self):
+        def fn(x):
+            import torch.fx
+
+            assert not isinstance(x, torch.fx.Proxy)
+            return torch.sin(x)
+
+        x = torch.randn(4, 5)
+        ref = fn(x)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize_assert(cnts):
+            res = fn(x)
+        self.assertTrue(same(ref, res))

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -366,8 +366,6 @@ class InstructionTranslatorBase(object):
         level, fromlist = self.popn(2)
         if level.as_python_constant() != 0:
             unimplemented("IMPORT_NAME with level")
-        if fromlist.as_python_constant() is not None:
-            unimplemented("IMPORT_NAME with fromlist")
 
         # Import name imports the top level package
         module_name = inst.argval.split(".")[0]

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -366,9 +366,13 @@ class InstructionTranslatorBase(object):
         level, fromlist = self.popn(2)
         if level.as_python_constant() != 0:
             unimplemented("IMPORT_NAME with level")
+        if fromlist.as_python_constant() is not None:
+            unimplemented("IMPORT_NAME with fromlist")
 
-        value = importlib.import_module(inst.argval)
-        source = self.import_source(inst.argval)
+        # Import name imports the top level package
+        module_name = inst.argval.split(".")[0]
+        value = importlib.import_module(module_name)
+        source = self.import_source(module_name)
 
         if is_allowed(value):
             self.push(TorchVariable(value, source=source))


### PR DESCRIPTION
Cpython eval import_name reference - https://github.com/python/cpython/blob/main/Python/ceval.c#L7199-L7227

It calls `PyImport_ImportModuleLevelObject` which uses `__import__` which returns the top level package.

PyImport_ImportModuleLevelObject doc - https://docs.python.org/3/c-api/import.html#c.PyImport_ImportModuleLevelObject

![image](https://user-images.githubusercontent.com/13822661/158466245-fab4c80e-9e52-4488-a271-f3d49eddb4ed.png)
