### PR TITLE
Fiddle with C++ and setup.py to fix build on M1 Max Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         CppExtension(
             name="torchdynamo._guards",
             sources=["torchdynamo/_guards.cpp"],
+            extra_compile_args=["-std=c++14"]
         ),
     ],
 )

--- a/torchdynamo/_eval_frame.c
+++ b/torchdynamo/_eval_frame.c
@@ -148,10 +148,12 @@ static void destroy_cache_entry(CacheEntry *e) {
   free(e);
 }
 
+#ifdef TORCHDYNAMO_DEBUG
 inline static const char *name(PyFrameObject *frame) {
   DEBUG_CHECK(PyUnicode_Check(frame->f_code->co_name));
   return PyUnicode_AsUTF8(frame->f_code->co_name);
 }
+#endif
 
 static void call_guard_fail_hook(PyObject *hook, CacheEntry *e,
                                  PyObject *f_locals) {


### PR DESCRIPTION
Made a few tweaks to make compilation work on a relatively fresh Mac with default version of clang. Let me know if there is a better way to do this, the ifdef is to handle name not being used when debugging is off, and clang defaults to an older C++ standard. 