### PR TITLE
Support __init__ of HF ModelOutput

### DIFF
--- a/tests/test_model_output.py
+++ b/tests/test_model_output.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env pytest
+import dataclasses
 import unittest.mock
 
 import torch
@@ -8,6 +9,7 @@ from torchdynamo.testing import same
 
 try:
     from transformers import modeling_outputs
+    from transformers.file_utils import ModelOutput
     from transformers.modeling_outputs import BaseModelOutput
 except ImportError:
     modeling_outputs = None
@@ -100,3 +102,41 @@ class TestModelOutput(torchdynamo.testing.TestCase):
             return obj[0] * 10 + obj[1]
 
         self._common(fn, 2)
+
+    @maybe_skip
+    def test_mo_init(self):
+        @dataclasses.dataclass
+        class MyDataClass(ModelOutput):
+            a: torch.Tensor
+            b: torch.Tensor = None
+            c: torch.Tensor = None
+            d: torch.Tensor = None
+            e: torch.Tensor = None
+
+        def fn(obj):
+            class_fields = dataclasses.fields(obj)
+            assert len(class_fields)
+            assert all(field.default is None for field in class_fields[1:])
+            other_fields_are_none = all(
+                getattr(obj, field.name) is None for field in class_fields[1:]
+            )
+            assert not other_fields_are_none
+
+            total = getattr(obj, class_fields[0].name)
+            for field in class_fields[1:]:
+                v = getattr(obj, field.name)
+                if v is not None:
+                    total += v
+
+            return total
+
+        tensors = [torch.randn(10), torch.randn(10), torch.randn(10)]
+        obj1 = MyDataClass(*tensors)
+        correct1 = fn(obj1)
+
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            obj2 = MyDataClass(*tensors)
+            self.assertTrue(same(fn(obj2), correct1))
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 2)

--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -208,14 +208,16 @@ class DataClassVariable(ConstDictVariable):
         excluded = []
         items = collections.OrderedDict()
         for key in keys:
-            val = getattr(obj, key)
-            var = builder.__class__(
-                tx=builder.tx, source=AttrSource(builder.source, key)
-            )(val)
-            if val is not None or cls.include_none:
-                items[key] = var
-            else:
-                excluded.append(var)
+            # __init__ function of a dataclass might not have yet defined the key
+            if hasattr(obj, key):
+                val = getattr(obj, key)
+                var = builder.__class__(
+                    tx=builder.tx, source=AttrSource(builder.source, key)
+                )(val)
+                if val is not None or cls.include_none:
+                    items[key] = var
+                else:
+                    excluded.append(var)
         return cls(
             user_cls, items, **VariableTracker.propagate(excluded, items.values())
         )


### PR DESCRIPTION
HF ModelOuput when sublclassed with dataclass decorator will have init function, where the subclass keys might still be undefined. This PR skips such undefined keys