### PR TITLE
Support formatted literal strings (f-strings)

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -521,3 +521,9 @@ class FunctionTests(torchdynamo.testing.TestCase):
         tmp = f"{x.shape[0]} bar"
         if tmp.startswith("10"):
             return x + 1
+
+    @make_test
+    def test_fstrings3(x):
+        tmp = f"{x.__class__.__name__} foo"
+        if tmp.startswith("Tensor"):
+            return x + 1

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -507,3 +507,17 @@ class FunctionTests(torchdynamo.testing.TestCase):
     def test_is_quantized(a, b):
         if not a.is_quantized:
             return a + b
+
+    @make_test
+    def test_fstrings1(a, b):
+        x = 1.229
+        tmp = f"{x:.2f} bar"
+        if tmp.startswith("1.23"):
+            return a + b
+
+    @requires_static_shapes
+    @make_test
+    def test_fstrings2(x):
+        tmp = f"{x.shape[0]} bar"
+        if tmp.startswith("10"):
+            return x + 1

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -855,6 +855,36 @@ class InstructionTranslatorBase(object):
         self.push(b)
         self.push(a)
 
+    def FORMAT_VALUE(self, inst):
+        flags = inst.arg
+        if (flags & 0x04) == 0x04:
+            fmt_spec = self.pop()
+        else:
+            fmt_spec = ConstantVariable("")
+
+        value = self.pop()
+
+        if (flags & 0x03) == 0x01:
+            self.call_function(BuiltinVariable(str), [value], {})
+            value = self.pop()
+        elif (flags & 0x03) == 0x02:
+            self.call_function(BuiltinVariable(repr), [value], {})
+            value = self.pop()
+        elif (flags & 0x03) == 0x03:
+            self.call_function(BuiltinVariable(ascii), [value], {})
+            value = self.pop()
+
+        self.push_many([ConstantVariable("{:"), fmt_spec, ConstantVariable("}")])
+        self.INPLACE_ADD(inst=None)
+        self.INPLACE_ADD(inst=None)
+        fmt_var = self.pop()
+
+        self.call_function(BuiltinVariable(str.format), [fmt_var, value], {})
+
+    def BUILD_STRING(self, inst):
+        for _ in range(inst.arg - 1):
+            self.INPLACE_ADD(inst=None)
+
     UNARY_POSITIVE = stack_op(operator.pos)
     UNARY_NEGATIVE = stack_op(operator.neg)
     UNARY_NOT = stack_op(operator.not_)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -865,25 +865,23 @@ class InstructionTranslatorBase(object):
         value = self.pop()
 
         if (flags & 0x03) == 0x01:
-            self.call_function(BuiltinVariable(str), [value], {})
-            value = self.pop()
+            value = BuiltinVariable(str).call_function(self, [value], {})
         elif (flags & 0x03) == 0x02:
-            self.call_function(BuiltinVariable(repr), [value], {})
-            value = self.pop()
+            value = BuiltinVariable(repr).call_function(self, [value], {})
         elif (flags & 0x03) == 0x03:
-            self.call_function(BuiltinVariable(ascii), [value], {})
-            value = self.pop()
+            value = BuiltinVariable(ascii).call_function(self, [value], {})
 
-        self.push_many([ConstantVariable("{:"), fmt_spec, ConstantVariable("}")])
-        self.INPLACE_ADD(inst=None)
-        self.INPLACE_ADD(inst=None)
-        fmt_var = self.pop()
+        fmt_var = ConstantVariable("{:" + fmt_spec.as_python_constant() + "}").add_options(fmt_spec)
 
         self.call_function(BuiltinVariable(str.format), [fmt_var, value], {})
 
     def BUILD_STRING(self, inst):
-        for _ in range(inst.arg - 1):
-            self.INPLACE_ADD(inst=None)
+        result = ""
+        for _ in range(inst.arg):
+            str_var = self.pop()
+            assert isinstance(str_var, ConstantVariable)
+            result = str_var.value + result
+        self.push(ConstantVariable(value=result))
 
     UNARY_POSITIVE = stack_op(operator.pos)
     UNARY_NEGATIVE = stack_op(operator.neg)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -871,7 +871,9 @@ class InstructionTranslatorBase(object):
         elif (flags & 0x03) == 0x03:
             value = BuiltinVariable(ascii).call_function(self, [value], {})
 
-        fmt_var = ConstantVariable("{:" + fmt_spec.as_python_constant() + "}").add_options(fmt_spec)
+        fmt_var = ConstantVariable(
+            "{:" + fmt_spec.as_python_constant() + "}"
+        ).add_options(fmt_spec)
 
         self.call_function(BuiltinVariable(str.format), [fmt_var, value], {})
 

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -47,6 +47,7 @@ class BuiltinVariable(VariableTracker):
             round,
             set,
             str,
+            str.format,
             sum,
             tuple,
             type,

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -172,6 +172,9 @@ class TensorVariable(VariableTracker):
         elif name == "ndim" and self.ndim is None:
             result = self.call_method(tx, "dim", [], {})
 
+        if name == "__class__":
+            return TorchVariable(torch.Tensor, **options)
+
         if result is None:
             raise NotImplementedError()
 

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -173,7 +173,7 @@ class TensorVariable(VariableTracker):
             result = self.call_method(tx, "dim", [], {})
 
         if name == "__class__":
-            return TorchVariable(torch.Tensor, **options)
+            return TorchVariable(self.python_type(), **options)
 
         if result is None:
             raise NotImplementedError()


### PR DESCRIPTION
Support formatted literal strings (f-strings) by rewriting [FORMAT_VALUE and BUILD_STRING](https://docs.python.org/3.8/library/dis.html#opcode-FORMAT_VALUE) bytecode.

Issue: https://github.com/facebookresearch/torchdynamo/issues/41