### PR TITLE
Remove `gc.collect()` upon every model run in benchmark

### DIFF
--- a/torchbench.py
+++ b/torchbench.py
@@ -162,7 +162,6 @@ def load_model(device, model_name, is_training, use_eval_mode):
 
 def timed(model, model_iter_fn, example_inputs, times=1, return_result=False):
     synchronize()
-    gc.collect()
     torch.manual_seed(1337)
     t0 = time.perf_counter()
     # Dont collect outputs to correctly measure timing


### PR DESCRIPTION
Currently we are doing `gc.collect()` before measuring the model computation latency. However, this also means we need to  run `cudaMalloc()` every time we run the model code. This is undesired because in benchmark we should expect to measure the latency of a "steady state run", in which we expect memory requests are mostly served from cached memory, and exclude the time cost by `cudaMalloc()`.

Reference: https://github.com/facebookresearch/torchdynamo/issues/107#issuecomment-1098507583