### PR TITLE
Handle torch.seed

### DIFF
--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -8,6 +8,8 @@ from typing import List
 
 import torch
 
+from torchdynamo.variables.tensor import SeedVariable
+
 from .. import config
 from .. import variables
 from ..allowed_functions import is_disallowed
@@ -94,6 +96,7 @@ class BuiltinVariable(VariableTracker):
     @functools.lru_cache(None)
     def _fx_graph_functions():
         fns = {
+            int,
             operator.pos,
             operator.neg,
             operator.not_,

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -8,7 +8,7 @@ from typing import List
 
 import torch
 
-from torchdynamo.variables.tensor import SeedVariable
+from torchdynamo.variables.tensor import DynamicShapeVariable
 
 from .. import config
 from .. import variables
@@ -201,7 +201,7 @@ class BuiltinVariable(VariableTracker):
                 unimplemented(f"partial tensor op: {self} {args} {kwargs}")
 
         # Handle cases like int(torch.seed())
-        if self.fn is int and isinstance(args[0], SeedVariable):
+        if self.fn is int and isinstance(args[0], DynamicShapeVariable):
             return args[0]
 
         handler = getattr(self, f"call_{self.fn.__name__}", None)

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -96,7 +96,6 @@ class BuiltinVariable(VariableTracker):
     @functools.lru_cache(None)
     def _fx_graph_functions():
         fns = {
-            int,
             operator.pos,
             operator.neg,
             operator.not_,
@@ -200,6 +199,10 @@ class BuiltinVariable(VariableTracker):
                 )
             except NotImplementedError:
                 unimplemented(f"partial tensor op: {self} {args} {kwargs}")
+
+        # Handle cases like int(torch.seed())
+        if self.fn is int and isinstance(args[0], SeedVariable):
+            return args[0]
 
         handler = getattr(self, f"call_{self.fn.__name__}", None)
 

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -106,6 +106,14 @@ class TensorVariable(VariableTracker):
                 )
         elif example_value is None or proxy.node.target is torch.manual_seed:
             return variables.ConstantVariable(None, **options)
+        elif istype(example_value, int) and proxy.node.target in (
+            torch.seed,
+            operator.mod,
+            int,
+        ):
+            # TODO - Is it possible to check that the args for mod and int is a SeedVariable
+            proxy.node.meta["example_value"] = example_value
+            return SeedVariable(proxy, **options)
         else:
             assert (
                 False
@@ -272,6 +280,14 @@ class TensorVariable(VariableTracker):
                 ),
                 **options,
             )
+
+
+class SeedVariable(TensorVariable):
+    def __init__(self, proxy, **kwargs):
+        super(SeedVariable, self).__init__(proxy, **kwargs)
+
+    def python_type(self):
+        return int
 
 
 class DynamicShapeVariable(TensorVariable):

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -76,6 +76,12 @@ class TensorVariable(VariableTracker):
             if isinstance(example_value, torch.Size):
                 options["dyn_shape_len"] = len(example_value)
             return DynamicShapeVariable(proxy, type(example_value), **options)
+        elif istype(example_value, int) and proxy.node.target in (
+            torch.seed,
+            operator.mod,
+        ):
+            proxy.node.meta["example_value"] = example_value
+            return DynamicShapeVariable(proxy, type(example_value), **options)
         elif istype(example_value, torch.Size) and all(
             [isinstance(x, int) for x in example_value]
         ):
@@ -106,14 +112,6 @@ class TensorVariable(VariableTracker):
                 )
         elif example_value is None or proxy.node.target is torch.manual_seed:
             return variables.ConstantVariable(None, **options)
-        elif istype(example_value, int) and proxy.node.target in (
-            torch.seed,
-            operator.mod,
-            int,
-        ):
-            # TODO - Is it possible to check that the args for mod and int is a SeedVariable
-            proxy.node.meta["example_value"] = example_value
-            return SeedVariable(proxy, **options)
         else:
             assert (
                 False
@@ -280,14 +278,6 @@ class TensorVariable(VariableTracker):
                 ),
                 **options,
             )
-
-
-class SeedVariable(TensorVariable):
-    def __init__(self, proxy, **kwargs):
-        super(SeedVariable, self).__init__(proxy, **kwargs)
-
-    def python_type(self):
-        return int
 
 
 class DynamicShapeVariable(TensorVariable):


### PR DESCRIPTION
@jansel This is probably the incorrect way, looking for feedback.

The generated Fx graph for 

~~~
        def fn(x):
            attention_seed = int(torch.seed() % sys.maxsize)
            torch.manual_seed(attention_seed)
            return ()
~~~

is 
~~~

def forward(self):
    seed = torch.random.seed()
    mod = seed % 9223372036854775807;  seed = None
    int_1 = int(mod);  mod = None
    manual_seed = torch.random.manual_seed(int_1);  int_1 = None
    return ()

~~~