### PR TITLE
Handle torch.cuda.current_device

### DIFF
--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -26,6 +26,7 @@ def _disallowed_function_ids():
         torch.autocast_increment_nesting,
         torch.autograd.grad,
         torch.clear_autocast_cache,
+        torch.cuda.current_device,
         torch.distributions.constraints.is_dependent,
         torch.distributions.normal.Normal,
         torch.inference_mode,


### PR DESCRIPTION
Doing a graph break on it. I thought about making it a ConstantVariable but then we would have to put a guard on it. Since, compiler can't do much by knowing this. I am putting a graph break.

Is this reasoning good?

![image](https://user-images.githubusercontent.com/13822661/163656796-67656270-90a2-4cee-aebb-935202f89dde.png)
