### PR TITLE
Support Slice of NNModuleList

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -262,6 +262,9 @@ class ModuleList(torch.nn.Module):
         for idx, layer in enumerate(self.layers):
             x = layer(x) * idx
 
+        for idx, layer in enumerate(self.layers[::-1]):
+            x = layer(x) * idx
+
         return x
 
 

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -278,21 +278,26 @@ class NNModuleVariable(VariableTracker):
                 torch.nn.ParameterList.__getitem__,
             ), typestr(module)
             assert self.source
+
             if isinstance(args[0], SliceVariable):
+                # Build a TupleVariable of NNModules
                 result = []
-                for submod in module[args[0].as_python_constant()]:
-                    name = key
-                    src = NNModuleSource(AttrSource(self.source, name))
+
+                # Turn the slice into the list of integers
+                keys = list(range(len(module)))[args[0].as_python_constant()]
+                for idx, submod in enumerate(module[args[0].as_python_constant()]):
+                    key = keys[idx]
+                    src = NNModuleSource(GetItemSource(self.source, key))
                     result.append(
                         tx.output.add_submodule(
                             submod,
                             key,
-                            name,
                             source=src,
                             **options,
                         )
                     )
                 return TupleVariable(result, **options)
+
             key = args[0].as_python_constant()
             submod = module[key]
             return tx.output.add_submodule(


### PR DESCRIPTION
@jansel I am not sure if this is correct. The guards do not look correct.

~~~

GUARDS:
 - local 'x' TENSOR_MATCH
 - local 'self' NN_MODULE
 - local_nn_module 'self.layers' NN_MODULE
 - local_nn_module 'self.layers[0]' NN_MODULE
 - local_nn_module 'self.layers.self_layers' NN_MODULE
~~~

for this testcase

~~~

class ModuleList(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.layers = torch.nn.ModuleList(
            [
                torch.nn.Linear(10, 10),
                torch.nn.ReLU(),
                torch.nn.Linear(10, 10),
                torch.nn.ReLU(),
            ]
        )

    def forward(self, x):
        x = self.layers[0](x) 
        x = self.layers[0:1:1][0](x)
        # for idx, layer in enumerate(self.layers[::-1]):
        #     x = layer(x) * idx

        return x


mod = ModuleList()
x = torch.randn(10, 10)
ref = mod(x)

with torchdynamo.optimize("eager", nopython=True):
    mod(x)
~~~