### PR TITLE
Fix import overhead by using `importlib.util.find_spec`

### DIFF
--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -122,6 +122,7 @@ for _name in (
 ):
     add(importlib.util.find_spec(_name))
 
+
 def is_torch_inline_allowed(filename):
     return filename.startswith(_module_dir(torch.nn)) or filename.startswith(
         _module_dir(torch.distributions)

--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -77,14 +77,14 @@ FILENAME_ALLOWLIST = {
 }
 
 
-def add(module_spec: typing.Optional[types.ModuleSpec]):
+def add(module_spec: typing.Optional[importlib.machinery.ModuleSpec]):
     if not module_spec:
         return
     global SKIP_DIRS_RE
     name = module_spec.origin
     if name is None:
         return
-    SKIP_DIRS.append(os.path.dirname(module_spec))
+    SKIP_DIRS.append(os.path.dirname(name))
     SKIP_DIRS_RE = re.compile(f"^({'|'.join(map(re.escape, SKIP_DIRS))})")
 
 

--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -77,13 +77,14 @@ FILENAME_ALLOWLIST = {
 }
 
 
-def add(module: types.ModuleType):
-    assert isinstance(module, types.ModuleType)
+def add(module_spec: typing.Optional[types.ModuleSpec]):
+    if not module_spec:
+        return
     global SKIP_DIRS_RE
-    name = module.__file__
+    name = module_spec.origin
     if name is None:
         return
-    SKIP_DIRS.append(_module_dir(module))
+    SKIP_DIRS.append(os.path.dirname(module_spec))
     SKIP_DIRS_RE = re.compile(f"^({'|'.join(map(re.escape, SKIP_DIRS))})")
 
 
@@ -119,11 +120,7 @@ for _name in (
     "tvm",
     "fx2trt_oss",
 ):
-    try:
-        add(importlib.import_module(_name))
-    except (ImportError, TypeError):
-        pass
-
+    add(importlib.util.find_spec(_name))
 
 def is_torch_inline_allowed(filename):
     return filename.startswith(_module_dir(torch.nn)) or filename.startswith(


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/torchdynamo/issues/133.
This also fixes the performance overhead caused by importing third party libraries in https://github.com/facebookresearch/torchdynamo/issues/107