### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/test-py39.yml
+++ b/.github/workflows/test-py39.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  test-py38:
+  test-py39:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-py39.yml
+++ b/.github/workflows/test-py39.yml
@@ -1,0 +1,23 @@
+name: Test Python 3.9
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-py38:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+    - run: make setup
+    - run: make test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email="jansel@fb.com",
     license="BSD-3",
     keywords="pytorch machine learning compilers",
-    python_requires=">=3.7, <3.9",
+    python_requires=">=3.7, <3.10",
     install_requires=["torch>=1.11.0", "numpy", "tabulate"],
     packages=find_packages(include=["torchdynamo", "torchdynamo.*"]),
     ext_modules=[

--- a/torchdynamo/bytecode_analysis.py
+++ b/torchdynamo/bytecode_analysis.py
@@ -8,9 +8,10 @@ TERMINAL_OPCODES = {
     dis.opmap["JUMP_ABSOLUTE"],
     dis.opmap["JUMP_FORWARD"],
     dis.opmap["RAISE_VARARGS"],
-    # dis.opmap["RERAISE"],
     # TODO(jansel): double check exception handling
 }
+if sys.version_info >= (3, 9):
+    TERMINAL_OPCODES.add(dis.opmap["RERAISE"])
 JUMP_OPCODES = set(dis.hasjrel + dis.hasjabs)
 HASLOCAL = set(dis.haslocal)
 HASFREE = set(dis.hasfree)
@@ -159,5 +160,5 @@ def stacksize_analysis(instructions):
         return low + 32
 
     assert fixed_point.value, "failed to reach fixed point"
-    # assert low >= 0
+    assert low >= 0
     return high

--- a/torchdynamo/bytecode_analysis.py
+++ b/torchdynamo/bytecode_analysis.py
@@ -159,5 +159,5 @@ def stacksize_analysis(instructions):
         return low + 32
 
     assert fixed_point.value, "failed to reach fixed point"
-    assert low >= 0
+    # assert low >= 0
     return high

--- a/torchdynamo/resume_execution.py
+++ b/torchdynamo/resume_execution.py
@@ -30,26 +30,61 @@ class ReenterWith:
     stack_index: int = None
 
     def __call__(self, code_options, cleanup):
-        with_cleanup_start = create_instruction("WITH_CLEANUP_START")
-        if sys.version_info < (3, 8):
-            begin_finally = create_instruction(
-                "LOAD_CONST", PyCodegen.get_const_index(code_options, None), None
-            )
-        else:
-            begin_finally = create_instruction("BEGIN_FINALLY")
-        cleanup[:] = [
-            create_instruction("POP_BLOCK"),
-            begin_finally,
-            with_cleanup_start,
-            create_instruction("WITH_CLEANUP_FINISH"),
-            create_instruction("END_FINALLY"),
-        ] + cleanup
+        if sys.version_info < (3, 9):
+            with_cleanup_start = create_instruction("WITH_CLEANUP_START")
+            if sys.version_info < (3, 8):
+                begin_finally = create_instruction(
+                    "LOAD_CONST", PyCodegen.get_const_index(code_options, None), None
+                )
+            else:
+                begin_finally = create_instruction("BEGIN_FINALLY")
+            cleanup[:] = [
+                create_instruction("POP_BLOCK"),
+                begin_finally,
+                with_cleanup_start,
+                create_instruction("WITH_CLEANUP_FINISH"),
+                create_instruction("END_FINALLY"),
+            ] + cleanup
 
-        return [
-            create_instruction("CALL_FUNCTION", 0),
-            create_instruction("SETUP_WITH", target=with_cleanup_start),
-            create_instruction("POP_TOP"),
-        ]
+            return [
+                create_instruction("CALL_FUNCTION", 0),
+                create_instruction("SETUP_WITH", target=with_cleanup_start),
+                create_instruction("POP_TOP"),
+            ]
+        else:
+
+            with_except_start = create_instruction("WITH_EXCEPT_START")
+            pop_top_after_with_except_start = create_instruction("POP_TOP")
+
+            cleanup_complete_jump_target = create_instruction("NOP")
+
+            cleanup[:] = [
+                create_instruction("POP_BLOCK"),
+                create_instruction(
+                    "LOAD_CONST", PyCodegen.get_const_index(code_options, None), None
+                ),
+                create_instruction("DUP_TOP"),
+                create_instruction("DUP_TOP"),
+                create_instruction("CALL_FUNCTION", 3),
+                create_instruction("POP_TOP"),
+                create_instruction("JUMP_FORWARD", target=cleanup_complete_jump_target),
+                with_except_start,
+                create_instruction("POP_JUMP_IF_TRUE", target=pop_top_after_with_except_start),
+                create_instruction("RERAISE"),
+                pop_top_after_with_except_start,
+                create_instruction("POP_TOP"),
+                create_instruction("POP_TOP"),
+                create_instruction("POP_EXCEPT"),
+                create_instruction("POP_TOP"),
+
+                cleanup_complete_jump_target
+            ] + cleanup
+
+            return [
+                create_instruction("CALL_FUNCTION", 0),
+                create_instruction("SETUP_WITH", target=with_except_start),
+                create_instruction("POP_TOP"),
+            ]
 
 
 @dataclasses.dataclass

--- a/torchdynamo/resume_execution.py
+++ b/torchdynamo/resume_execution.py
@@ -69,15 +69,16 @@ class ReenterWith:
                 create_instruction("POP_TOP"),
                 create_instruction("JUMP_FORWARD", target=cleanup_complete_jump_target),
                 with_except_start,
-                create_instruction("POP_JUMP_IF_TRUE", target=pop_top_after_with_except_start),
+                create_instruction(
+                    "POP_JUMP_IF_TRUE", target=pop_top_after_with_except_start
+                ),
                 create_instruction("RERAISE"),
                 pop_top_after_with_except_start,
                 create_instruction("POP_TOP"),
                 create_instruction("POP_TOP"),
                 create_instruction("POP_EXCEPT"),
                 create_instruction("POP_TOP"),
-
-                cleanup_complete_jump_target
+                cleanup_complete_jump_target,
             ] + cleanup
 
             return [

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -911,6 +911,7 @@ class InstructionTranslatorBase(object):
                     BaseListVariable,
                     UserDefinedVariable,
                     BaseUserFunctionVariable,
+                    ConstDictVariable,
                 ),
             )
             and isinstance(right, ConstantVariable)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -918,12 +918,10 @@ class InstructionTranslatorBase(object):
         ):
             # <non-None> is None
             self.push(ConstantVariable(operator.is_(object(), right.value), **options))
-        elif (left.is_python_constant() and right.is_python_constant()):
+        elif left.is_python_constant() and right.is_python_constant():
             self.push(
                 ConstantVariable(
-                    operator.is_(
-                        left.as_python_constant(), right.as_python_constant()
-                    ),
+                    operator.is_(left.as_python_constant(), right.as_python_constant()),
                     **options,
                 )
             )
@@ -948,7 +946,10 @@ class InstructionTranslatorBase(object):
         list.extend(obj.items, list(v.unpack_var_sequence(self)))
         self.replace_all(
             obj,
-            ListVariable(obj.items, **VariableTracker.propagate([obj, v]),)
+            ListVariable(
+                obj.items,
+                **VariableTracker.propagate([obj, v]),
+            ),
         )
 
     def LIST_TO_TUPLE(self, inst):
@@ -963,7 +964,10 @@ class InstructionTranslatorBase(object):
         collections.OrderedDict.update(obj.items, v.items)
         self.replace_all(
             obj,
-            ConstDictVariable(obj.items, **VariableTracker.propagate([obj, v]),)
+            ConstDictVariable(
+                obj.items,
+                **VariableTracker.propagate([obj, v]),
+            ),
         )
 
     UNARY_POSITIVE = stack_op(operator.pos)


### PR DESCRIPTION
Changes:

* ```_eval_frame.c```
  * Use ```_PyInterpreterState_SetEvalFrameFunc``` to enable/disable eval frame for Python >= 3.9.
  * Refactor ```custom_eval_frame``` as ```_PyFrameEvalFunction``` has a new arg ```PyThreadState *tstate``` if Python >= 3.9
  * Use ```PyFrame_New``` to replace ```_PyFrame_New_NoTrack``` which is not public API after Python 3.9. Meanwhile, the ```PyFrame_New``` includes ```PyObject_GC_UnTrack``` so we have to untrack it after the function call.

* Implement the new version of ```ReenterWith.__call__``` cleanup logics.

* Add several new bytecodes:
  * IS_OP
  * CONTAINS_OP
  * LIST_EXTEND
  * LIST_TO_TUPLE
  * DICT_MERGE
* Bump Python version in setup.py.
* Add Python 3.9 github test workflow.
 
Test:
* All unit tests passed.
* All models in torchbenchmark passed.
  
Issue: https://github.com/facebookresearch/torchdynamo/issues/33