### PR TITLE
moco and hf_Reformer fixes

### DIFF
--- a/torchbench.py
+++ b/torchbench.py
@@ -71,15 +71,12 @@ SKIP_TRAIN = {
     # Unusual training setup
     "opacus_cifar10",
     "maml",
-    # TorchDynamo and AOT errors
-    "hf_Reformer",
 }
 
 # Some models have bad train dataset. We read eval dataset.
 # yolov3 - seems to have different number of inputs between eval and train
-# densenet121 - OOM for train, using eval for now.
 # timm_efficientdet - loader only exists for eval mode.
-ONLY_EVAL_DATASET = {"yolov3", "densenet121", "timm_efficientdet"}
+ONLY_EVAL_DATASET = {"yolov3", "timm_efficientdet"}
 
 # These models support only train mode. So accuracy checking can't be done in
 # eval mode.
@@ -98,9 +95,9 @@ REQUIRE_HIGHER_TOLERANCE = {
 # Some models have large dataset that doesn't fit in memory. Lower the batch
 # size to test the accuracy.
 USE_SMALL_BATCH_SIZE = {
-    "timm_efficientdet": 1,
     "demucs": 4,
     "hf_Reformer": 4,
+    "timm_efficientdet": 1,
 }
 
 current_name = ""
@@ -1049,9 +1046,10 @@ def run_one_model(
         sys.stdout.flush()
         for submod in itertools.chain([model], model.modules()):
             assert not torchdynamo.utils.is_jit_model(submod)
-        torch.manual_seed(1337)
 
+        torch.manual_seed(1337)
         correct_result = model_iter_fn(copy.deepcopy(model), example_inputs)
+
         torch.manual_seed(1337)
         if current_name != "pyhpc_turbulent_kinetic_energy":
             correct_rerun_result = model_iter_fn(copy.deepcopy(model), example_inputs)

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -59,10 +59,17 @@ class AOTAutogradStrategy(object):
             if isinstance(ex, torch.nn.parameter.Parameter):
                 has_param_as_input = True
 
+        # 3) set_grad_enabled
+        has_set_grad_enabled = False
+        for node in self.gm.graph.nodes:
+            if node.target == torch._C._set_grad_enabled:
+                has_set_grad_enabled = True
+
         if (
             has_mutation(self.gm, self.example_inputs)
             or len(gm_inputs) == 0
             or has_param_as_input
+            or has_set_grad_enabled
         ):
             self.use_fallback = True
 

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -83,6 +83,8 @@ class TensorVariable(VariableTracker):
         elif istype(example_value, int) and proxy.node.target in (
             torch.seed,
             operator.mod,
+            torch.distributed.get_rank,
+            torch.distributed.get_world_size,
         ):
             proxy.node.meta["example_value"] = example_value
             return DynamicShapeVariable(proxy, type(example_value), **options)


### PR DESCRIPTION
* `moco` - Support `torch.distributed.get_rank`, `torch.distributed.get_world_size`
* `hf_Reformer` - Do not send to AOT Autograd if it has `torch._C.set_enable_grad`