### PR TITLE
enable support for classmethod on superclass

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -427,6 +427,24 @@ class SuperModule(BasicModule):
         return x + 10.0
 
 
+class ComplicatedSuperParent(torch.nn.Module):
+    @classmethod
+    def custom_add(cls, x):
+        x = x + x
+        return x
+
+
+class SuperChildCallsClassMethod(ComplicatedSuperParent):
+    @classmethod
+    def child_func(self, x):
+        x = super().custom_add(x)
+        return x
+
+    def forward(self, x):
+        x = self.child_func(x)
+        return x
+
+
 class HasAttrModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -531,6 +549,7 @@ class NNModuleTests(torchdynamo.testing.TestCase):
     test_stringmember = make_test(StringMember())
     test_modulelist = make_test(ModuleList())
     test_super1 = make_test(SuperModule())
+    test_super_class_method = make_test(SuperChildCallsClassMethod())
     test_children = make_test(Children())
     test_densenet = make_test(DenseNetBlocks())
     test_parameters1 = make_test(ParametersModule1())


### PR DESCRIPTION
Summary:

Adds support for tracing through this syntax:

```
class Parent(torch.nn.Module):
    @classmethod
    def foo(cls, x):
        x = x + x
        return x

class Child(Parent):
    @classmethod
    def helper(cls, x):
        // resolving super().foo failed before this PR
        x = super().foo(x)
        return x

    def forward(self, x):
        x = self.helper(x)
        return x
```

This is useful for eventually enabling __torch_function__ support.

Note: I don't know much about the codebase, please feel free to point out
n00b shortcomings. I left some questions in the implementation which
would be good to resolve before landing.

Test plan:

```
pytest -vsk test_super_class_method
```