### PR TITLE
Options to print fx/aot traces

### DIFF
--- a/torchbench.py
+++ b/torchbench.py
@@ -340,6 +340,21 @@ def overhead_experiment(*args, model_iter_fn):
     return speedup_experiment(*args, model_iter_fn)
 
 
+def print_fx(gm, example_inputs):
+    print(gm.graph)
+    return gm
+
+
+def print_aten_ops(gm, example_inputs):
+    from functorch.compile import aot_module
+
+    def trace_printer(gm, _):
+        print(gm.graph)
+        return gm
+
+    return aot_module(gm, fw_compiler=trace_printer, bw_compiler=trace_printer)
+
+
 def baselines(models, model_iter_fn, example_inputs, args):
     """
     Common measurement code across all baseline experiments.
@@ -705,6 +720,16 @@ def main():
         help="Accuracy testing and speedup for AOT with Torchscript(NNC/NVFuser) with mincut vs Eager",
     )
     group.add_argument(
+        "--print-fx",
+        action="store_true",
+        help="Print fx traces captured from model",
+    )
+    group.add_argument(
+        "--print-aten-ops",
+        action="store_true",
+        help="Print traces of aten ops captured by AOT autograd",
+    )
+    group.add_argument(
         "--accuracy-ts",
         action="store_true",
         help="Accuracy testing and speedup using Torchscript (NNC/NVFuser) vs eager",
@@ -887,6 +912,16 @@ def main():
         experiment = speedup_experiment
         backend_str = "nvfuser" if args.nvfuser else "nnc"
         output_filename = f"accuracy_aot_{backend_str}_mincut.csv"
+    elif args.print_fx:
+        optimize_ctx = torchdynamo.optimize(
+            print_fx,
+            nopython=args.nopython,
+        )
+    elif args.print_aten_ops:
+        optimize_ctx = torchdynamo.optimize(
+            print_aten_ops,
+            nopython=args.nopython,
+        )
     elif args.accuracy_ts:
         optimize_ctx = torchdynamo.optimize(fixed_strategy1, nopython=args.nopython)
         experiment = speedup_experiment


### PR DESCRIPTION
I've heard from a few different people who want to capture traces of popular workloads for analysis, and dynamo/fx/aot_autograd make this possible, and this script makes running torchbench fairly tractable.