### PR TITLE
modify 'ipex' backend

### DIFF
--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -22,8 +22,7 @@ def has_onnxruntime():
 
 def has_ipex():
     try:
-        import intel_extension_for_pytorch
-
+        importlib.import_module("intel_extension_for_pytorch")
         return True
     except ImportError:
         return False

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 
 import torchdynamo
+from torchdynamo.optimizations import backends
 from torchdynamo.optimizations.inference import offline_autotuner
 from torchdynamo.optimizations.normalize import Inplacifier
 from torchdynamo.optimizations.normalize import normalize
@@ -14,6 +15,15 @@ from torchdynamo.testing import same
 def has_onnxruntime():
     try:
         importlib.import_module("onnxruntime")
+        return True
+    except ImportError:
+        return False
+
+
+def has_ipex():
+    try:
+        import intel_extension_for_pytorch
+
         return True
     except ImportError:
         return False
@@ -31,6 +41,17 @@ class Seq(torch.nn.Module):
 
     def forward(self, x):
         return self.layers(x)
+
+
+class Conv_Bn_Relu(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, **kwargs):
+        super(Conv_Bn_Relu, self).__init__()
+        self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=False, **kwargs)
+        self.bn = torch.nn.BatchNorm2d(out_channels, eps=0.001)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(self.bn(self.conv(x)))
 
 
 class TestOptimizations(torchdynamo.testing.TestCase):
@@ -74,3 +95,29 @@ class TestOptimizations(torchdynamo.testing.TestCase):
         with torchdynamo.optimize_assert(offline_autotuner):
             r2 = s(i)
         self.assertTrue(same(r1, r2))
+
+    @unittest.skipIf(not has_ipex(), "requires ipex")
+    def test_ipex_fp32(self):
+        model = Conv_Bn_Relu(3, 32, kernel_size=3, stride=1)
+        model = model.to(memory_format=torch.channels_last)
+        model = model.eval()
+        input = torch.randn(8, 3, 64, 64).contiguous(memory_format=torch.channels_last)
+        r1 = model(input)
+        with torchdynamo.optimize(backends.ipex_fp32), torch.no_grad():
+            r2 = model(input)
+        self.assertTrue(same(r1, r2))
+        self.assertEqual(r2.dtype, torch.float32)
+
+    @unittest.skipIf(not has_ipex(), "requires ipex")
+    def test_ipex_bf16(self):
+        model = Conv_Bn_Relu(3, 32, kernel_size=3, stride=1)
+        model = model.to(memory_format=torch.channels_last)
+        model = model.eval()
+        input = torch.randn(8, 3, 64, 64).contiguous(memory_format=torch.channels_last)
+        r1 = model(input)
+        with torchdynamo.optimize(
+            backends.ipex_bf16
+        ), torch.no_grad(), torch.cpu.amp.autocast():
+            r2 = model(input)
+        self.assertTrue(same(r1, r2.float(), tol=0.1))
+        self.assertEqual(r2.dtype, torch.bfloat16)

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -281,14 +281,15 @@ def taso(subgraph):
 @create_backend
 def ipex(subgraph, **kwargs):
     import intel_extension_for_pytorch as ipex
+
     inputs = subgraph.example_inputs
     model = subgraph.model
     with torch.no_grad():
         model.eval()
-        if kwargs["datatype"] == 'bf16':
-            model = ipex.optimize(model, dtype= torch.bfloat16)
+        if kwargs["datatype"] == "bf16":
+            model = ipex.optimize(model, dtype=torch.bfloat16)
         else:
-            model = ipex.optimize(model, dtype= torch.float32)
+            model = ipex.optimize(model, dtype=torch.float32)
         try:
             traced_model = torch.jit.trace(model, inputs).eval()
             traced_model = torch.jit.freeze(traced_model)
@@ -696,12 +697,12 @@ def ltc_trivial(gm: torch.fx.GraphModule, example_inputs):
 
 
 def ipex_fp32(gm: torch.fx.GraphModule, example_inputs):
-    kwargs_ipex = {"datatype": 'fp32'}
+    kwargs_ipex = {"datatype": "fp32"}
     return BACKENDS["ipex"](gm, example_inputs, **kwargs_ipex)
 
 
 def ipex_bf16(gm: torch.fx.GraphModule, example_inputs):
-    kwargs_ipex = {"datatype": 'bf16'}
+    kwargs_ipex = {"datatype": "bf16"}
     return BACKENDS["ipex"](gm, example_inputs, **kwargs_ipex)
 
 

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -5,6 +5,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import warnings
 
 import numpy as np
 import torch
@@ -297,7 +298,8 @@ def ipex(subgraph, **kwargs):
             for i in range(3):
                 traced_model(*inputs)
             return traced_model
-        except:
+        except Exception:
+            warnings.warn("JIT trace failed during the 'ipex' optimize process.")
             return model
 
 


### PR DESCRIPTION
Modify ’ipex‘ backend:
1. Support two datatypes: float32 and bfloat16,
2. JIT trace to obtain more optimization opportunities, such as fusion, weights prepack etc.