### PR TITLE
enable basic __torch_function__ support

### DIFF
--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -20,6 +20,7 @@ from .utils import rot_n_helper
 from .variables.base import VariableTracker
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import TensorVariable
+from .variables.tensor import TensorWithTFOverrideVariable
 
 
 @dataclasses.dataclass
@@ -90,7 +91,10 @@ class PyCodegen(object):
             value.as_python_constant()
         ):
             output.append(self.create_load_const(value.as_python_constant()))
-        elif isinstance(value, TensorVariable):
+        elif isinstance(value, (TensorVariable, TensorWithTFOverrideVariable)):
+            if isinstance(value, TensorWithTFOverrideVariable):
+                # unwrap back to tensor
+                value = value.tensor_variable
             graph_outputs_key = id(value.proxy)
             if graph_outputs_key not in graph_outputs:
                 graph_outputs[graph_outputs_key] = GraphOutputEntry(

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -40,3 +40,7 @@ dynamic_propagation = True
 
 # run FX normalization passes in optimizer
 normalize_ir = True
+
+# If a tensor subclass type is in this set, torchdynamo will inline the
+# __torch_function__ logic of the subclass.
+traceable_tensor_subclasses = set()

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -17,6 +17,8 @@ from typing import Dict
 import torch
 from torch import fx
 
+from . import config
+
 log = logging.getLogger(__name__)
 counters = collections.defaultdict(collections.Counter)
 
@@ -78,7 +80,9 @@ def istype(obj, allowed_types):
 
 def istensor(obj):
     """Check of obj is a tensor"""
-    return istype(obj, (torch.Tensor, torch.nn.Parameter))
+    return istype(
+        obj, (torch.Tensor, torch.nn.Parameter, *config.traceable_tensor_subclasses)
+    )
 
 
 @functools.lru_cache(4096)

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -13,6 +13,7 @@ from ..guards import GuardBuilder
 from ..guards import GuardSource
 from ..source import AttrSource
 from ..utils import identity
+from ..utils import proxy_args_kwargs
 from .base import VariableTracker
 
 
@@ -35,10 +36,14 @@ class SuperVariable(VariableTracker):
         assert self.objvar, "1-arg super not implemented"
         search_type = self.typevar.as_python_constant()
 
-        # We default to the python type of the object. However, if this is a
-        # `type`, then the original object represents the user defined type.
+        # We default to the python type of the object. However,
+        # 1. If this is a `type`, then the original object represents the user
+        # defined type.
+        # 2. If this is `torch._C._TensorMeta`, the original object is the user
+        # defined type of a custom tensor subclass.
+        # TODO(future PR): figure out how to do this in a less hacky way
         type_to_use = self.objvar.python_type()
-        if type_to_use is type:
+        if type_to_use is type or type_to_use is torch._C._TensorMeta:
             type_to_use = self.objvar.value
 
         # TODO(jansel): there is a small chance this could trigger user code, prevent that
@@ -269,6 +274,42 @@ class GetAttrVariable(VariableTracker):
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
+
+        # This variable is True when it corresponds to user code such as
+        #
+        #   super().__torch_function__(...)
+        #
+        # and the super().__torch_function__ attribute resolves
+        # to torch.Tensor.__torch_function__.
+        is_original_tensor_torch_function = (
+            self.name == "__torch_function__"
+            and isinstance(self.obj, SuperVariable)
+            # for now, only support one level of inheritance
+            and len(self.obj.objvar.value.__mro__) > 1
+            and self.obj.objvar.value.__mro__[1] == torch.Tensor
+        )
+        if is_original_tensor_torch_function:
+            # Instead of tracing inside torch.Tensor.__torch_function__,
+            # record the `call_function` call into the graph.
+            from . import TensorVariable
+
+            original_torch_variable = args[0]
+            new_args = args[2].items
+            new_kwargs = args[3].items
+            options = VariableTracker.propagate(self, new_args, new_kwargs.values())
+            # Disable __torch_function__ here to prevent the clone of the
+            # example tensor from going into the override.
+            with torch._C.DisableTorchFunction():
+                return TensorVariable.create(
+                    tx=tx,
+                    proxy=tx.output.create_proxy(
+                        "call_function",
+                        original_torch_variable.value,
+                        *proxy_args_kwargs(new_args, new_kwargs),
+                    ),
+                    **options,
+                )
+
         if isinstance(self.obj, AutogradFunctionVariable) and self.name == "apply":
             return self.obj.call_apply(tx, args, kwargs).add_options(self)
         return self.obj.call_method(tx, self.name, args, kwargs).add_options(self)

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -305,3 +305,21 @@ class DynamicShapeVariable(TensorVariable):
                 for i in range(self.dyn_shape_len)
             ]
         super(DynamicShapeVariable, self).unpack_var_sequence(tx)
+
+
+class TensorWithTFOverrideVariable(VariableTracker):
+    """
+    Represents a tensor subclass instance with a __torch_function__ override.
+    """
+
+    def __init__(
+        self,
+        tensor_variable,
+        subclass_torch_function__func,
+        subclass_type,
+        **kwargs,
+    ):
+        super(TensorWithTFOverrideVariable, self).__init__(**kwargs)
+        self.tensor_variable = tensor_variable
+        self.subclass_torch_function__func = subclass_torch_function__func
+        self.subclass_type = subclass_type


### PR DESCRIPTION
Summary:

This adds a skeleton for `__torch_function__` support in torchdynamo.

What this is currently doing:
1. in variable builder, check for `__torch_function__` and wrap tensors in `TensorTFOverrideVariable` if found
1. in `TorchVariable.call_function`, inline the `__torch_function__` function of `TensorTFOverrideVariable` arguments
2. in `GetAttrVariable.call_function`, check for `super().__torch_function__` which resolves to the original. If it's found, stop inlining and insert the function call into the graph.

The current test just creates a `__torch_function__` override which doesn't do
anything but call `super().__torch_function__`.

Things left for future PRs:
1. supporting `call_method`
2. supporing actual logic inside the overrides
3. implementing the full `__torch_function__` spec (currently things are hardcoded to first argument only)

Test plan:

```
pytest -vsk test_simple_torch_function
// used to fail with https://www.internalfb.com/phabricator/paste/view/P496842415
// currently passes
```