### PR TITLE
Fixes for pytorch tests - 1/n

### DIFF
--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -53,6 +53,8 @@ def _allowed_function_ids():
     def _find_torch_objects(module):
         if module.__name__.startswith("torch.distributions"):
             return
+        if module.__name__.startswith("torch.testing"):
+            return
         torch_object_ids[id(module)] = module.__name__
         for name, obj in list(module.__dict__.items()):
             if id(obj) not in torch_object_ids:

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -19,6 +19,7 @@ from .bytecode_transformation import transform_code_object
 from .eval_frame import skip_code
 from .exc import InternalTorchDynamoError
 from .exc import RestartAnalysis
+from .exc import TorchRuntimeError
 from .exc import Unsupported
 from .exc import unimplemented
 from .guards import GuardedCode
@@ -177,7 +178,7 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
             assert output.guards is not None
             CleanupManager.instance[code] = output.cleanups
             return GuardedCode(code, output.guards, frame.f_locals, frame.f_globals)
-        except Unsupported:
+        except (Unsupported, TorchRuntimeError):
             debug_print("WONT CONVERT")
             raise
         except Exception:

--- a/torchdynamo/exc.py
+++ b/torchdynamo/exc.py
@@ -12,6 +12,10 @@ class RestartAnalysis(RuntimeError):
     pass
 
 
+class TorchRuntimeError(RuntimeError):
+    pass
+
+
 class Unsupported(RuntimeError):
     def __init__(self, msg):
         super(Unsupported, self).__init__(msg)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -36,6 +36,7 @@ from .bytecode_transformation import is_generator
 from .bytecode_transformation import unique_id
 from .codegen import PyCodegen
 from .exc import RestartAnalysis
+from .exc import TorchRuntimeError
 from .exc import Unsupported
 from .exc import unimplemented
 from .output_graph import OutputGraph
@@ -277,7 +278,7 @@ class InstructionTranslatorBase(object):
                 and self.step()
             ):
                 pass
-        except (Unsupported, RestartAnalysis):
+        except (Unsupported, RestartAnalysis, TorchRuntimeError):
             raise
         except Exception as e:
             sys.stderr.write(

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -359,7 +359,11 @@ class SkipFilesVariable(VariableTracker):
         if inspect.getattr_static(self.value, "_torchdynamo_disable", False):
             unimplemented("call torchdynamo.disable() wrapped function")
         else:
-            unimplemented("call_function in skip_files " + inspect.getfile(self.value))
+            try:
+                path = inspect.getfile(self.value)
+            except TypeError:
+                path = f"Builtin {self.value.__name__}"
+            unimplemented("call_function in skip_files " + path)
 
 
 class NumpyVariable(VariableTracker):

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -84,10 +84,9 @@ class TensorVariable(VariableTracker):
                         assert nnmodule is not None
                         example_value = copy.deepcopy(nnmodule)(*args, **kwargs)
                 except RuntimeError:
-                    # Call the pytorch operator leads to an assertion
+                    # Track the assertion when the pytorch execution raises
+                    # assertion
                     raise TorchRuntimeError
-                except Exception:
-                    raise
 
         if isinstance(example_value, torch.Tensor):
             proxy.node.meta["example_value"] = clone_tensor(example_value)


### PR DESCRIPTION
Multiple changes in one PR (happy to break it down if needed)
* Filter torch.testing
* Adding is_complex, and is_contiguous
* Do not raise Dynamo assertion when Torch operation itself raises assertion. This is for cases like follows. Created a new type of assertion - TorchRuntimeError.
~~~
import torch
import torchdynamo

def fn(x, y):
    try:
        x.expand_as(y)
    except RuntimeError:
        return False
    return True

x = torch.randn(4)
y = torch.randn(10)
ref = fn(x, y)

with torchdynamo.optimize("eager"):
    res = fn(x, y)

print("Success")
~~~


