### PR TITLE
extend __torch_function__ support to `call_method`

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -600,8 +600,9 @@ class NNModuleTests(torchdynamo.testing.TestCase):
             # function call, twice to test wrapping
             x = F.sigmoid(x)
             x = F.sigmoid(x)
-            # TODO(future PR): support method calls
-            # x = x.sigmoid()
+            # method call, twice to test wrapping
+            x = x.sigmoid()
+            x = x.sigmoid()
             return x
 
         class TensorProxy(torch.Tensor):
@@ -617,5 +618,5 @@ class NNModuleTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnt, nopython=True):
             out2 = foo(x)
 
-        self.assertEqual(cnt.op_count, 2)
+        self.assertEqual(cnt.op_count, 4)
         self.assertTrue(torchdynamo.testing.same(out1, out2))


### PR DESCRIPTION
Summary:

In https://github.com/facebookresearch/torchdynamo/pull/167 we added `__torch_function__`
support for tracing through `call_function`.

This PR extends the support to also work on `call_method`.

Note: the LOC is high because some code was refactored to be reusable.
Note: implementing correct rewrapping logic for methods is saved for a
future PR, hope that's OK.

Test plan:

```
pytest -vsk test_simple_torch_function
```