### PR TITLE
Fixes for pytorch tests 2/n - torch.Size and nn.Parameter

### DIFF
--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -118,7 +118,12 @@ class VariableBuilder:
         elif istype(value, (tuple, list)) or is_namedtuple(value):
             # One can index a tensor with a list/tuple. Therefore, we need to
             # have a stricter match.
-            guards = self.make_guards(GuardBuilder.EQUALS_MATCH)
+            if istype(value, (tuple, list)) and all(
+                [isinstance(x, int) or x is None for x in value]
+            ):
+                guards = self.make_guards(GuardBuilder.EQUALS_MATCH)
+            else:
+                guards = self.make_guards(GuardBuilder.LIST_LENGTH)
             output = [
                 VariableBuilder(self.tx, GetItemSource(self.get_source(), i))(
                     item

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -116,7 +116,9 @@ class VariableBuilder:
         if istensor(value):
             return self.wrap_tensor(value)
         elif istype(value, (tuple, list)) or is_namedtuple(value):
-            guards = self.make_guards(GuardBuilder.LIST_LENGTH)
+            # One can index a tensor with a list/tuple. Therefore, we need to
+            # have a stricter match.
+            guards = self.make_guards(GuardBuilder.EQUALS_MATCH)
             output = [
                 VariableBuilder(self.tx, GetItemSource(self.get_source(), i))(
                     item

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -232,7 +232,21 @@ class TupleVariable(BaseListVariable):
 class SizeVariable(TupleVariable):
     """torch.Size(...)"""
 
-    pass
+    def python_type(self):
+        return torch.Size
+
+    def reconstruct(self, codegen):
+        load_torch_size = [
+            create_instruction("LOAD_GLOBAL", "torch"),
+            create_instruction("LOAD_METHOD", "Size"),
+        ]
+        codegen.extend_output(load_torch_size)
+        codegen.foreach(self.items)
+        build_torch_size = [
+            create_instruction("BUILD_TUPLE", len(self.items)),
+            create_instruction("CALL_METHOD", 1),
+        ]
+        return build_torch_size
 
 
 class NamedTupleVariable(TupleVariable):

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -173,6 +173,7 @@ class TensorVariable(VariableTracker):
         is_quantized=None,
         is_contiguous=None,
         is_complex=None,
+        class_type=torch.Tensor,
         **kwargs,
     ):
         super(TensorVariable, self).__init__(**kwargs)
@@ -186,12 +187,13 @@ class TensorVariable(VariableTracker):
         self.is_quantized = is_quantized
         self.is_contiguous = is_contiguous
         self.is_complex = is_complex
+        self.class_type = class_type
 
     def as_proxy(self):
         return self.proxy
 
     def python_type(self):
-        return torch.Tensor
+        return self.class_type
 
     @staticmethod
     def specialize(value: torch.Tensor):
@@ -202,6 +204,7 @@ class TensorVariable(VariableTracker):
             "requires_grad": value.requires_grad,
             "is_quantized": value.is_quantized,
             "is_complex": value.is_complex(),
+            "class_type": type(value),
         }
         if not config.dynamic_shapes:
             props["size"] = tuple(value.size())
@@ -269,7 +272,7 @@ class TensorVariable(VariableTracker):
         if name == "stride" and self.stride is not None:
             constant_result = ConstantVariable(self.stride, **options)
         elif name == "size" and self.size is not None:
-            constant_result = ConstantVariable(self.size, **options)
+            constant_result = SizeVariable(self.size, **options)
         elif name == "numel" and self.size is not None:
             constant_result = ConstantVariable(product(self.size), **options)
         elif name in ("ndimension", "dim") and self.ndim is not None:

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -272,7 +272,8 @@ class TensorVariable(VariableTracker):
         if name == "stride" and self.stride is not None:
             constant_result = ConstantVariable(self.stride, **options)
         elif name == "size" and self.size is not None:
-            constant_result = SizeVariable(self.size, **options)
+            sizes = [variables.ConstantVariable(x) for x in self.size]
+            constant_result = SizeVariable(sizes, **options)
         elif name == "numel" and self.size is not None:
             constant_result = ConstantVariable(product(self.size), **options)
         elif name in ("ndimension", "dim") and self.ndim is not None:


### PR DESCRIPTION
* Save the Tensor Type information like `torch.nn.Parameter` vs `torch.Tensor`
* torch.Size - Handle reconstruction logic to return torch.Size instead of a tuple
* List check - Use EQUALS_MATCH because tensor can be indexed with a list. This might cause the case of too-much-specialization, but is needed for correctness.