### PR TITLE
Fix for `KeyError: 'Size'` error

### DIFF
--- a/torchbench.py
+++ b/torchbench.py
@@ -1095,6 +1095,8 @@ def run_one_model(
     cos_similarity=False,
     skip_accuracy_check=False,
 ):
+    t0 = time.perf_counter()
+
     tolerance = 1e-4
     # Increase the tolerance for torch allclose
     if is_training and current_device == "cuda" and name in REQUIRE_HIGHER_TOLERANCE:
@@ -1152,7 +1154,9 @@ def run_one_model(
             frames_third_pass = 0
 
         if output_filename and "coverage" in output_filename:
-            results.append(f"{ok:3}/{total:3} +{frames_third_pass} frames")
+            results.append(
+                f"{ok:3}/{total:3} +{frames_third_pass} frames {time.perf_counter()-t0:.0f}s"
+            )
 
         results.append(experiment(model, example_inputs))
         print(" ".join(map(str, results)))

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -236,15 +236,11 @@ class SizeVariable(TupleVariable):
         return torch.Size
 
     def reconstruct(self, codegen):
-        load_torch_size = [
-            create_instruction("LOAD_GLOBAL", "torch"),
-            create_instruction("LOAD_METHOD", "Size"),
-        ]
-        codegen.extend_output(load_torch_size)
+        codegen.load_import_from("torch", "Size")
         codegen.foreach(self.items)
         build_torch_size = [
             create_instruction("BUILD_TUPLE", len(self.items)),
-            create_instruction("CALL_METHOD", 1),
+            create_instruction("CALL_FUNCTION", 1),
         ]
         return build_torch_size
 


### PR DESCRIPTION

```
Traceback (most recent call last):
  File "/home/jansel/torchdynamo/torchdynamo/convert_frame.py", line 170, in _convert_frame_assert
    code = transform_code_object(frame.f_code, transform)
  File "/home/jansel/torchdynamo/torchdynamo/bytecode_transformation.py", line 340, in transform_code_object
    fix_vars(instructions, code_options)
  File "/home/jansel/torchdynamo/torchdynamo/bytecode_transformation.py", line 307, in fix_vars
    instructions[i].arg = names[instructions[i].argval]
KeyError: 'Size'
```

The prior version only worked if the global "torch" was used elsewhere in the function.